### PR TITLE
Moved to credentials to separate file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Settings file
+# Credentials
+email-credentials.json
+
 # Webstorm settings
 .idea/
 

--- a/email-credentials.json.example
+++ b/email-credentials.json.example
@@ -1,0 +1,4 @@
+[
+	{"username": "user"},
+	{"password": "password"}
+]

--- a/tests/Resources/keywords_kontakt-vgr_vgrform.robot
+++ b/tests/Resources/keywords_kontakt-vgr_vgrform.robot
@@ -11,16 +11,23 @@ Test Contact Message
 
   #  [Documentation] Tests "Kontakta Mig"
 
+      # Get username and password for email account
+    ${CredentialFileContents}=    Get File    ../email-credentials.json
+
+    ${credentials}=         Evaluate            json.loads("""${CredentialFileContents}""")    json
+    ${username}=    Set Variable        ${credentials['username']}
+    ${password}=    Set Variable        ${credentials['password']}
+
     Input Text                  css:#namn                   Testrobot
-    Input Text                  css:#epost                  test20014565@gmail.com
+    Input Text                  css:#epost                  ${username}
     Input Text                  css:#fraga                  Testmail
     Input Text                  css:#CapthcaQuestion        4
     Click Element               name:XFormsSubmit_ybNPBoUY03n4AhQramlZUl7tjg8B8hlyI9EGjjv64
   #  Go To                        https://accounts.google.com/ServiceLogin/signinchooser?service=mail&passive=true&rm=false&continue=https%3A%2F%2Fmail.google.com%2Fmail%2F&ss=1&scc=1&ltmpl=default&ltmplcache=2&emr=1&osid=1&flowName=GlifWebSignIn&flowEntry=ServiceLogin
-  #  Input Text                   name:identifier             test20014565@gmail.com
+  #  Input Text                   name:identifier             ${username}
   #  Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
   #  Sleep                        3s
-  #  Input Text                   name:password               Vgregiontest
+  #  Input Text                   name:password               ${password}
   #  Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
 
 

--- a/tests/Resources/keywords_prenumeration_nyhetsbrev.robot
+++ b/tests/Resources/keywords_prenumeration_nyhetsbrev.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Documentation
+Library  OperatingSystem
 Library  SeleniumLibrary
 
 *** Keywords ***
@@ -8,15 +9,23 @@ Test Subscribe
 
     # [Documentation] Subscribes to newsletter on page
 
-    Input Text              id:EmailAdress      test20014565@gmail.com
+    # Get username and password for email account
+    ${CredentialFileContents}=    Get File    ../email-credentials.json
+
+    ${credentials}=         Evaluate            json.loads("""${CredentialFileContents}""")    json
+    ${username}=    Set Variable        ${credentials['username']}
+    ${password}=    Set Variable        ${credentials['password']}
+
+
+    Input Text              id:EmailAdress      ${username}
     Click Element           css:[name="ButtonAction"][value="Prenumerera"]
     Sleep                                   1s
     Go To                        https://accounts.google.com/ServiceLogin/signinchooser?service=mail&passive=true&rm=false&continue=https%3A%2F%2Fmail.google.com%2Fmail%2F&ss=1&scc=1&ltmpl=default&ltmplcache=2&emr=1&osid=1&flowName=GlifWebSignIn&flowEntry=ServiceLogin
     Sleep                                   1s
-    Input Text                   name:identifier             test20014565@gmail.com
+    Input Text                   name:identifier             ${username}
     Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
     Sleep                        3s
-    Input Text                   name:password               Vgregiontest
+    Input Text                   name:password               ${password}
     Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
     Wait Until Page Contains     Prenumerera på nyhetsbrev
 
@@ -24,13 +33,20 @@ Test Unsubscribe
 
     # [Documentation] Unsubscribes to newsletter on page
 
-    Input Text              id:EmailAdress      test20014565@gmail.com
+    # Get username and password for email account
+    ${CredentialFileContents}=    Get File    ../email-credentials.json
+
+    ${credentials}=         Evaluate            json.loads("""${CredentialFileContents}""")    json
+    ${username}=    Set Variable        ${credentials['username']}
+    ${password}=    Set Variable        ${credentials['password']}
+
+    Input Text              id:EmailAdress      ${username}
     Click Element           css:[name="ButtonAction"][value="Avprenumerera"]
     Sleep                                   1s
     Go To                        https://accounts.google.com/ServiceLogin/signinchooser?service=mail&passive=true&rm=false&continue=https%3A%2F%2Fmail.google.com%2Fmail%2F&ss=1&scc=1&ltmpl=default&ltmplcache=2&emr=1&osid=1&flowName=GlifWebSignIn&flowEntry=ServiceLogin
-    Input Text                   name:identifier             test20014565@gmail.com
+    Input Text                   name:identifier             ${username}
     Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
     Sleep                        3s
-    Input Text                   name:password               Vgregiontest
+    Input Text                   name:password               ${password}
     Click Element                xpath:/html/body/div[1]/div[1]/div[2]/div/div[2]/div/div/div[2]/div/div[2]/div/div[1]/div/div/button
     Wait Until Page Contains     Avprenumerera på nyhetsbrev

--- a/tests/prenumeration_nyhetsbrev.robot
+++ b/tests/prenumeration_nyhetsbrev.robot
@@ -1,5 +1,8 @@
 *** Settings ***
-Documentation
+# Documentation
+# NOTE: Make sure to create a email-credentials.json from email-credentials.json.example
+
+
 Resource  Resources/keywords_prenumeration_nyhetsbrev.robot
 Resource  Resources/keywords_general.robot
 Library  SeleniumLibrary
@@ -12,16 +15,7 @@ ${URL} =  https://www.vgregion.se/ov/data-och-analys/nyhetsbrev-och-seminarier/a
 
 *** Test Cases ***
 
-Test Listen
-    Test Listen Function
 
-Verify Header Is Visible
-
-    Verify If Header Menu Is Visible
-
-Verify Sök Function
-
-    Verify Sök Function Is Working
 
 Subscribe To Newsletter
     Test Subscribe
@@ -29,5 +23,4 @@ Subscribe To Newsletter
 Unsubscribe To Newsletter
     Test Unsubscribe
 
-Fetch Links And Check Responsecode
-    Get All Links And Return Response Code
+


### PR DESCRIPTION
It's not good practice having credentials in the repo (even if a throwaway email), so it's probably best to have it separated.

Should we write instructions in the readme-file? And should this be an optional test? (if not because it's trickier to setup the credentials textfile on the server)

Could the code be streamlined? there's a lot of repitition now. Maybe a function to fetch the credentials?